### PR TITLE
feat: add host parameter to route configuration functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func defineHost2Routes(group *echo.Group) {
 }
 
 // routeNotFoundSpecifier defines behavior for unspecified routes.
-func routeNotFoundSpecifier(group *echo.Group) error {
+func routeNotFoundSpecifier(_ string, group *echo.Group) error {
    // Route handler for unspecified routes, returns a not-found message.
    group.RouteNotFound("/*", func(c echo.Context) error {
       return c.String(http.StatusNotFound, "No known route")

--- a/example/main.go
+++ b/example/main.go
@@ -35,7 +35,7 @@ func defineHost2Routes(group *echo.Group) {
 }
 
 // routeNotFoundSpecifier defines behavior for unspecified routes.
-func routeNotFoundSpecifier(group *echo.Group) error {
+func routeNotFoundSpecifier(_ string, group *echo.Group) error {
 	// Route handler for unspecified routes, returns a not-found message.
 	group.RouteNotFound("/*", func(c echo.Context) error {
 		return c.String(http.StatusNotFound, "No known route")

--- a/hostroute.go
+++ b/hostroute.go
@@ -29,7 +29,7 @@ func SecureAgainstUnknownHosts(knownHosts map[string]bool) echo.MiddlewareFunc {
 }
 
 // SetupHostBasedRoutes configures routing based on hostnames.
-func SetupHostBasedRoutes(e *echo.Echo, hostConfigs []HostConfig, genericHosts []string, secureAgainstUnknownHosts bool, additionalHostConfig ...func(*echo.Group) error) error {
+func SetupHostBasedRoutes(e *echo.Echo, hostConfigs []HostConfig, genericHosts []string, secureAgainstUnknownHosts bool, additionalHostConfig ...func(string, *echo.Group) error) error {
 	var allHosts []string
 
 	for _, hostConfig := range hostConfigs {
@@ -40,7 +40,7 @@ func SetupHostBasedRoutes(e *echo.Echo, hostConfigs []HostConfig, genericHosts [
 		}
 		if len(additionalHostConfig) > 0 {
 			for _, config := range additionalHostConfig {
-				err := config(hostGroup) // Apply additional configurations if provided
+				err := config(hostConfig.Host, hostGroup) // Apply additional configurations if provided
 				if err != nil {
 					return err // Return on error
 				}
@@ -65,7 +65,7 @@ func SetupHostBasedRoutes(e *echo.Echo, hostConfigs []HostConfig, genericHosts [
 
 		if len(additionalHostConfig) > 0 {
 			for _, config := range additionalHostConfig {
-				err := config(genericGroup) // Apply additional configurations
+				err := config(genericHost, genericGroup) // Apply additional configurations
 				if err != nil {
 					return err // Return on error
 				}

--- a/hostroute_test.go
+++ b/hostroute_test.go
@@ -33,7 +33,7 @@ func noRouteHandler(c echo.Context) error {
 	return c.String(http.StatusNotFound, "No known route")
 }
 
-func noRouteSpecifier(group *echo.Group) error {
+func noRouteSpecifier(_ string, group *echo.Group) error {
 	group.RouteNotFound("*", noRouteHandler)
 	return nil
 }


### PR DESCRIPTION
- Updated `routeNotFoundSpecifier` and `noRouteSpecifier` to accept a string parameter for host, enhancing configurability.
- Modified `SetupHostBasedRoutes` to pass hostnames to additional configuration functions, enabling host-specific routing setups.
- This change improves the flexibility and clarity of route configuration, making it easier to manage routes based on hostnames.